### PR TITLE
Add support for link references

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -248,6 +248,28 @@ function trim(API, text) {
     return ret;
 }
 
+// schemes are registered in the IANA list
+var reUrl = /^(https?|github|ftps?|mailto|file|data|irc):\/\/[\S]+$/;
+
+/**
+ * Return true if the given string contains translatable text,
+ * and false otherwise. For example, a string extracted with only
+ * punctuation or only an URL in it is not translatable.
+ *
+ * @param {string} str the string to test
+ * @returns {boolean} true if the given string contains translatable text,
+ * and false otherwise.
+ */
+MarkdownFile.prototype.isTranslatable = function(str) {
+    if (!str || !str.length || !str.trim().length) return false;
+
+    reUrl.startIndex = 0;
+    var match = reUrl.exec(str);
+    if (match && match.length) return false;
+
+    return this.API.utils.containsActualText(str);
+}
+
 /**
  * @param {boolean} escape true if you want the translated
  * text to be escaped for attribute values
@@ -260,7 +282,7 @@ MarkdownFile.prototype._emitText = function(escape) {
 
     logger.trace('text using message accumulator is: ' + text);
 
-    if (text.length) {
+    if (this.isTranslatable(text)) {
         this._addTransUnit(text, this.comment);
     }
     var prefixes = this.message.getPrefix();
@@ -271,16 +293,6 @@ MarkdownFile.prototype._emitText = function(escape) {
             end.localizable = false;
         }
     });
-
-    /*
-    var parts = trim(text);
-
-    logger.trace('text using message accumulator is: ' + text);
-
-    if (parts.text.length) {
-        this._addTransUnit(parts.text, this.comment);
-    }
-    */
 
     this.comment = undefined;
     this.message = new MessageAccumulator();
@@ -431,8 +443,9 @@ MarkdownFile.prototype._walk = function(node) {
             this._emitText();
             break;
 
+        case 'linkReference':
         case 'inlineCode':
-            // inline code nodes are non-breaking and self-closing
+            // inline code nodes and link references are non-breaking and self-closing
             if (this.message.getTextLength()) {
                 node.localizable = true;
                 this.message.push(node);
@@ -499,6 +512,16 @@ MarkdownFile.prototype._walk = function(node) {
             this._emitText();
             if (node.children && node.children.length) {
                 node.children.forEach(function(child, index, array) {
+                    if (child.type === 'linkReference' &&
+                            child.children &&
+                            child.children.length &&
+                            child.children[0].type === "text") {
+                            // Don't need to localize the text nodes inside of linkReferences
+                            // because that text should correspond with the text in the
+                            // references below. So just avoid it and recreate it later during
+                            // the localization step if necessary
+                            child.children = [];
+                    }
                     this._walk(child);
                 }.bind(this));
             }
@@ -693,6 +716,17 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
             }
             break;
 
+        case 'linkReference':
+            if (node.localizable) {
+                node.add(new Node({
+                    type: 'text',
+                    value: node.label
+                }));
+                message.push(node);
+                message.pop();
+            }
+            break;
+
         case 'inlineCode':
             // inline code is a non-breaking, self-closing node
             if (node.localizable) {
@@ -800,6 +834,14 @@ function flattenHtml(node) {
 
 function mapToAst(node) {
     var children = [];
+
+    if (node.type === "linkReference") {
+        node.add(new Node({
+            type: 'text',
+            value: node.label
+        }));
+    }
+
     for (var i = 0; i < node.children.length; i++) {
         var child = mapToAst(node.children[i]);
         if (child.type === "html") {
@@ -810,7 +852,9 @@ function mapToAst(node) {
         }
     }
     if (node.extra) {
-        node.extra.children = children;
+        if (children.length) {
+            node.extra.children = node.extra.children ? node.extra.children.concat(children) : children;
+        }
         return node.extra;
     }
     return u(node.type, node, children);
@@ -907,7 +951,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
             }
             end = i;
         } else if (start > -1) {
-            if (ma.getTextLength()) {
+            if (this.isTranslatable(ma.getMinimalString())) {
                 var nodes = this._getTranslationNodes(locale, translations, ma);
                 if (nodes) {
                     // replace the source nodes with the translation nodes

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -759,6 +759,105 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseDontExtractURLOnlyLinks: function(test) {
+        test.expect(7);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            'Here are some links:\n\n' +
+            '* [http://www.box.com/foobar](http://www.box.com/foobar)\n' +
+            '* [http://www.box.com/asdf](http://www.box.com/asdf)\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+        test.equal(set.size(), 1);
+
+        var r = set.getBySource("Here are some links:");
+        test.ok(r);
+        test.equal(r.getSource(), "Here are some links:");
+        test.equal(r.getKey(), "r539503678");
+
+        // the URLs should not be extracted if they are the only thing in the string
+        r = set.getBySource("http://www.box.com/foobar");
+        test.ok(!r);
+
+        test.done();
+    },
+
+    testMarkdownFileParseDoExtractURLLinksMidString: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [http://www.box.com/foobar](http://www.box.com/foobar) system.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing <c0>http://www.box.com/foobar</c0> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0>http://www.box.com/foobar</c0> system.");
+        test.equal(r.getKey(), "r598935364");
+
+        test.done();
+    },
+
+    testMarkdownFileParseReferences: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [C1] system.\n\n' +
+                '[C1] http://www.box.com/foobar\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing <c0/> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0/> system.");
+        test.equal(r.getKey(), "r1010312382");
+
+        test.done();
+    },
+
+    testMarkdownFileParseNotOnlyReference: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing system.\n\n' +
+                '[C1] As referenced before.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "r699762575");
+
+        r = set.getBySource("As referenced before.");
+        test.ok(r);
+        test.equal(r.getSource(), "As referenced before.");
+        test.equal(r.getKey(), "r335185216");
+
+        test.done();
+    },
+
     testMarkdownFileParseNonBreakingInlineCode: function(test) {
         test.expect(5);
 
@@ -1570,6 +1669,60 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
             'Ceci est un `test` du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithLinkReference: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency [C1] parsing system.\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r858031024",
+            source: "This is a test of the emergency <c0/> parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique de l'urgence <c0/>.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique de l\'urgence [C1].\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithMultipleLinkReferences: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency [C1] parsing system [R1].\n\n[C1] https://www.box.com/test1\n[R1] http://www.box.com/about.html\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r90710505",
+            source: "This is a test of the emergency <c0/> parsing system <c1/>.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique <c1/> de l'urgence <c0/>.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique [R1] de l\'urgence [C1].\n\n[C1] <https://www.box.com/test1>\n[R1] <http://www.box.com/about.html>\n');
 
         test.done();
     },


### PR DESCRIPTION
Now link references do not cause a break in the text. Instead, they are hidden as coded text using the XML-like tags.