### PR TITLE
Fix a crash, and add ability to keep inline code in the source

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -284,15 +284,15 @@ MarkdownFile.prototype._emitText = function(escape) {
 
     if (this.isTranslatable(text)) {
         this._addTransUnit(text, this.comment);
-    }
-    var prefixes = this.message.getPrefix();
-    var suffixes = this.message.getSuffix();
+        var prefixes = this.message.getPrefix();
+        var suffixes = this.message.getSuffix();
 
-    prefixes.concat(suffixes).forEach(function(end) {
-        if (typeof(end) === "object") {
-            end.localizable = false;
-        }
-    });
+        prefixes.concat(suffixes).forEach(function(end) {
+            if (typeof(end) === "object") {
+                end.localizable = false;
+            }
+        });
+    }
 
     this.comment = undefined;
     this.message = new MessageAccumulator();
@@ -446,9 +446,10 @@ MarkdownFile.prototype._walk = function(node) {
         case 'linkReference':
         case 'inlineCode':
             // inline code nodes and link references are non-breaking and self-closing
+            // Also, pass true to the push so that this node is never optimized out of a string.
             if (this.message.getTextLength()) {
                 node.localizable = true;
-                this.message.push(node);
+                this.message.push(node, true);
                 this.message.pop();
             }
             break;
@@ -722,7 +723,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                     type: 'text',
                     value: node.label
                 }));
-                message.push(node);
+                message.push(node, true);
                 message.pop();
             }
             break;
@@ -730,7 +731,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
         case 'inlineCode':
             // inline code is a non-breaking, self-closing node
             if (node.localizable) {
-                message.push(node);
+                message.push(node, true);
                 message.pop();
             }
             break;
@@ -876,6 +877,21 @@ MarkdownFile.prototype._getTranslationNodes = function(locale, translations, ma)
         var nodes = transMa.root.toArray();
         // don't return the "root" start and end nodes
         nodes = nodes.slice(1, -1);
+
+        // warn about components in the target that don't exist in the source,
+        // and remove them from the node array as if they didn't exist
+        var maxIndex = Object.keys(ma.getMapping()).length;
+        var mismatch = false;
+
+        for (i = 0; i < nodes.length; i++) {
+           if (nodes[i].type == 'component' && (!nodes[i].extra || nodes[i].index > maxIndex)) {
+               nodes.splice(i, 1);
+               mismatch = true;
+           }
+        }
+        if (mismatch) {
+            logger.warn("Warning! Translation of\n'" + text + "' (key: " + key + ")\nto locale " + locale + " is\n'" + translation + "'\nwhich has a more components in it than the source.");
+        }
 
         if (this.project.settings.identify) {
             var tmp = [];

--- a/package.json
+++ b/package.json
@@ -54,24 +54,24 @@
     },
     "dependencies": {
         "he": "^1.2.0",
-        "ilib": "^14.1.0",
-        "ilib-tree-node": "^1.1.0",
+        "ilib": "^14.3.0",
         "log4js": "^2.11.0",
         "message-accumulator": "^2.2.0",
-        "rehype-raw": "^4.0.0",
-        "remark-highlight.js": "^5.1.0",
-        "remark-html": "^9.0.0",
+        "ilib-tree-node": "^1.2.2",
+        "rehype-raw": "^4.0.1",
+        "remark-highlight.js": "^5.1.1",
+        "remark-html": "^9.0.1",
         "remark-parse": "^6.0.3",
-        "remark-rehype": "^4.0.0",
+        "remark-rehype": "^4.0.1",
         "remark-stringify": "^6.0.4",
         "unified": "^7.1.0",
-        "unist-builder": "^1.0.3",
-        "unist-util-filter": "^1.0.0",
-        "unist-util-map": "^1.0.4",
-        "unist-util-visit": "^1.4.0"
+        "unist-builder": "^1.0.4",
+        "unist-util-filter": "^1.0.2",
+        "unist-util-map": "^1.0.5",
+        "unist-util-visit": "^1.4.1"
     },
     "devDependencies": {
-        "loctool": "^2.1.0",
+        "loctool": "^2.2.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         "ilib": "^14.1.0",
         "ilib-tree-node": "^1.1.0",
         "log4js": "^2.11.0",
-        "message-accumulator": "^2.0.2",
+        "message-accumulator": "^2.2.0",
         "rehype-raw": "^4.0.0",
         "remark-highlight.js": "^5.1.0",
         "remark-html": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1042,6 +1042,37 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseListWithTextAfter2: function(test) {
+        test.expect(9);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            'The viewer can be embedded in an IFrame, or linked directly. The URL pattern for the viewer is:\n\n' +
+            '* **https://cloud.app.box.com/viewer/{FileID}?options**\n\n' +
+            'The File ID can be obtained from the API or from the web application user interface.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+
+        var r = set.getBySource("The viewer can be embedded in an IFrame, or linked directly. The URL pattern for the viewer is:");
+        test.ok(r);
+        test.equal(r.getSource(), "The viewer can be embedded in an IFrame, or linked directly. The URL pattern for the viewer is:");
+        test.equal(r.getKey(), "r220720707");
+
+        var r = set.getBySource("The File ID can be obtained from the API or from the web application user interface.");
+        test.ok(r);
+        test.equal(r.getSource(), "The File ID can be obtained from the API or from the web application user interface.");
+        test.equal(r.getKey(), "r198589153");
+
+        test.done();
+    },
+
     testMarkdownFileParseNonBreakingEmphasisOutside: function(test) {
         test.expect(5);
 
@@ -1673,6 +1704,35 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeTextWithInlineCodeAtTheEnd: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('Delete the file with this command: `git rm filename`\n');
+
+        // should not optimize out inline code at the end of strings so that it can be
+        // part of the text that is translated
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r66239583",
+            source: "Delete the file with this command: <c0/>",
+            sourceLocale: "en-US",
+            target: "Avec cette commande <c0/>, vous pouvez supprimer le fichier.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Avec cette commande `git rm filename`, vous pouvez supprimer le fichier.\n');
+
+        test.done();
+    },
+
     testMarkdownFileLocalizeTextWithLinkReference: function(test) {
         test.expect(2);
 
@@ -1882,6 +1942,64 @@ module.exports.markdown = {
 
         test.equal(mf.localizeText(translations, "fr-FR"),
                 'Ceci est <span id="foo" class="bar"> un essai du système d\'analyse syntaxique de <em>l\'urgence.</em></span>\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextMismatchedNumberOfComponents: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a <em>test</em> of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        // there is no c1 in the source, so this better not throw an exception
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r306365966",
+            source: "This is a <c0>test</c0> of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <c0>essai</c0> du système d'analyse <c1>syntaxique</c1> de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        // Should ignore the c1 as if it weren't there
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <em>essai</em> du système d\'analyse syntaxique de l\'urgence.\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextMismatchedNumberOfComponentsSelfClosing: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a <em>test</em> of the emergency parsing system.\n');
+
+        var translations = new TranslationSet();
+        // there is no c1 in the source, so this better not throw an exception
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r306365966",
+            source: "This is a <c0>test</c0> of the emergency parsing system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un <c0>essai</c0> du système d'analyse <c1/> syntaxique de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        // Should ignore the c1 as if it weren't there
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un <em>essai</em> du système d\'analyse  syntaxique de l\'urgence.\n');
 
         test.done();
     },


### PR DESCRIPTION
* Fixed a crash that happens when there are more components in the translation than the source string. Now it
just gives a warning and proceeds as if that extra component were not there.
* Added the ability to keep reference links and inline code snippets with the string, even when
they are at the beginning or end of the string. They are not optimized out. Other components that
appear at the beginning or end of the string are still optimized out as normal.