### PR TITLE
Use the frontmatter remark plugin to parse and stringify the front matter

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -34,6 +34,7 @@ var remark2rehype = require('remark-rehype');
 var highlight = require('remark-highlight.js');
 var raw = require('rehype-raw');
 var stringify = require('remark-stringify');
+var frontmatter = require('remark-frontmatter');
 var he = require("he");
 var unistFilter = require('unist-util-filter');
 var unistMap = require('unist-util-map');
@@ -51,6 +52,7 @@ var mdparser = unified().
         commonmark: true,
         gfm: true
     }).
+    use(frontmatter, ['yaml']).
     use(highlight).
     use(remark2rehype).
     use(raw);
@@ -63,7 +65,8 @@ var mdstringify = unified().
         ruleSpaces: false,
         bullet: '*',
         listItemIndent: 1
-    })();
+    }).
+    use(frontmatter, ['yaml'])();
 
 function escapeQuotes(str) {
     var ret = "";

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "message-accumulator": "^2.2.0",
         "ilib-tree-node": "^1.2.2",
         "rehype-raw": "^4.0.1",
+        "remark-frontmatter": "^1.3.2",
         "remark-highlight.js": "^5.1.1",
         "remark-html": "^9.0.1",
         "remark-parse": "^6.0.3",

--- a/test/testfiles/md/test3.md
+++ b/test/testfiles/md/test3.md
@@ -1,0 +1,15 @@
+---
+title: This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+status: this front matter should remain unlocalized
+---
+
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+==================================
+
+This is some text. This is more text. Pretty, pretty text.
+
+This is localizable text. This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+
+This is the last bit of localizable text.
+
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.


### PR DESCRIPTION
This plugin ignores the front matter. Later we can scan it if necessary after it has been parsed and someone has put some localizable things in it.