### PR TITLE
Fix html comment parsing

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -471,7 +471,7 @@ MarkdownFile.prototype._walk = function(node) {
 
         case 'html':
             reTagName.lastIndex = 0;
-            if (node.value.substring(0, 4) === '<!--') {
+            if (node.value.trim().substring(0, 4) === '<!--') {
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ## Release Notes
 
+### 1.2.3
+
+- Fixed a bug where HTML comments were not recognized and skipped properly 
+if there was whitespace/indentation before them in the source file.
+
 ### 1.2.2
 
 - Fixed reference link support. If there is text in a reference link, then it will

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.2.2",
+    "version": "1.2.3",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2968,5 +2968,51 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseHTMLComments: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a <!-- comment -->test of the emergency parsing system.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "r699762575");
+
+        test.done();
+    },
+
+    testMarkdownFileParseHTMLCommentsWithIndent: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing system.\n  <!-- comment -->\nA second string\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
+        test.equal(r.getKey(), "r699762575");
+
+        var r = set.getBySource("A second string");
+        test.ok(r);
+        test.equal(r.getSource(), "A second string");
+        test.equal(r.getKey(), "r772298159");
+
+        test.done();
+    },
 
 };


### PR DESCRIPTION
- Fixed a bug where HTML comments were not recognized and skipped properly 
if there was whitespace/indentation before them in the source file.