### PR TITLE
Fix html comment parsing on the localization side

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -778,7 +778,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
 
         case 'html':
             reTagName.lastIndex = 0;
-            if (node.value.substring(0, 4) === '<!--') {
+            if (node.value.trim().substring(0, 4) === '<!--') {
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ## Release Notes
 
+### 1.2.4
+
+- The previous fix where HTML comments were not recognized and skipped properly 
+was only fixed for the parsing side of this plugin. Now it is fixed for the
+localization side as well.
+
 ### 1.2.3
 
 - Fixed a bug where HTML comments were not recognized and skipped properly 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.2.3",
+    "version": "1.2.4",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3015,4 +3015,44 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeHTMLCommentsWithIndent: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing system.\n  <!-- comment -->\nA second string\n');
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r699762575',
+            source: 'This is a test of the emergency parsing system.',
+            target: 'This is a test of the emergency parsing system... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r772298159',
+            source: 'A second string',
+            target: 'A second string... in GERMAN!',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        var expected =
+            'This is a test of the emergency parsing system... in GERMAN!\n\n  <!-- comment -->\n\nA second string... in GERMAN!\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
 };


### PR DESCRIPTION
The previous fix only fixed the parsing side of the plugin. This fix does the same thing for the localization side of the plugin.