### PR TITLE
Add support for shortcut and full link references

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -452,8 +452,21 @@ MarkdownFile.prototype._walk = function(node) {
             // Also, pass true to the push so that this node is never optimized out of a string,
             // even at the beginning or end.
             node.localizable = true;
+            if (node.referenceType === "shortcut") {
+                // convert to a full reference with a text child
+                // so that we can have a separate label and translated title
+                if (!node.children || !node.children.length) {
+                    var child = new Node({
+                        type: "text",
+                        value: node.label,
+                        children: []
+                    });
+                    node.children.push(child);
+                }
+                node.referenceType = "full";
+            }
             this.message.push(node, true);
-            if (node.children) {
+            if (node.children && node.children.length) {
                 node.children.forEach(function(child) {
                     this._walk(child);
                 }.bind(this));
@@ -722,7 +735,6 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
 
         case 'linkReference':
             if (node.localizable) {
-                console.dir(node);
                 if (node.use === "start") {
                     message.push(node, true);
                 } else if (node.use === "startend") {

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "unist-util-visit": "^1.4.1"
     },
     "devDependencies": {
-        "loctool": "^2.2.0",
+        "loctool": "^2.3.2",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -759,6 +759,50 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseReferenceLinksWithTitle: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the [emergency parsing][emer_sys] system.\n\n' +
+            '[emer_sys]: http://www.test.com/\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the <c0>emergency parsing</c0> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the <c0>emergency parsing</c0> system.");
+        test.equal(r.getKey(), "r848003676");
+
+        test.done();
+    },
+
+    testMarkdownFileParseReferenceLinksWithoutTitle: function(test) {
+        test.expect(5);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the [emergency parsing] system.\n\n' +
+            '[emergency parsing]: http://www.test.com/\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the <c0>emergency parsing</c0> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the <c0>emergency parsing</c0> system.");
+        test.equal(r.getKey(), "r848003676");
+
+        test.done();
+    },
+
     testMarkdownFileParseDontExtractURLOnlyLinks: function(test) {
         test.expect(7);
 
@@ -823,37 +867,10 @@ module.exports.markdown = {
         var set = mf.getTranslationSet();
         test.ok(set);
 
-        var r = set.getBySource("This is a test of the emergency parsing <c0/> system.");
+        var r = set.getBySource("This is a test of the emergency parsing <c0>C1</c0> system.");
         test.ok(r);
-        test.equal(r.getSource(), "This is a test of the emergency parsing <c0/> system.");
-        test.equal(r.getKey(), "r1010312382");
-
-        test.done();
-    },
-
-    testMarkdownFileParseNotOnlyReference: function(test) {
-        test.expect(8);
-
-        var mf = new MarkdownFile({
-            project: p
-        });
-        test.ok(mf);
-
-        mf.parse('This is a test of the emergency parsing system.\n\n' +
-                '[C1]: As referenced before.\n');
-
-        var set = mf.getTranslationSet();
-        test.ok(set);
-
-        var r = set.getBySource("This is a test of the emergency parsing system.");
-        test.ok(r);
-        test.equal(r.getSource(), "This is a test of the emergency parsing system.");
-        test.equal(r.getKey(), "r699762575");
-
-        r = set.getBySource("<c0/>: As referenced before.");
-        test.ok(r);
-        test.equal(r.getSource(), "<c0/>: As referenced before.");
-        test.equal(r.getKey(), "r650576171");
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0>C1</c0> system.");
+        test.equal(r.getKey(), "r475244008");
 
         test.done();
     },
@@ -1836,10 +1853,10 @@ module.exports.markdown = {
         var translations = new TranslationSet();
         translations.add(new ResourceString({
             project: "foo",
-            key: "r858031024",
-            source: "This is a test of the emergency <c0/> parsing system.",
+            key: "r1017266258",
+            source: "This is a test of the emergency <c0>C1</c0> parsing system.",
             sourceLocale: "en-US",
-            target: "Ceci est un test du système d'analyse syntaxique de l'urgence <c0/>.",
+            target: "Ceci est un test du système d'analyse syntaxique de l'urgence <c0>C1</c0>.",
             targetLocale: "fr-FR",
             datatype: "markdown"
         }));
@@ -1863,10 +1880,10 @@ module.exports.markdown = {
         var translations = new TranslationSet();
         translations.add(new ResourceString({
             project: "foo",
-            key: "r90710505",
-            source: "This is a test of the emergency <c0/> parsing system <c1/>.",
+            key: "r817759238",
+            source: "This is a test of the emergency <c0>C1</c0> parsing system <c1>R1</c1>.",
             sourceLocale: "en-US",
-            target: "Ceci est un test du système d'analyse syntaxique <c1/> de l'urgence <c0/>.",
+            target: "Ceci est un test du système d'analyse syntaxique <c1>R1</c1> de l'urgence <c0>C1</c0>.",
             targetLocale: "fr-FR",
             datatype: "markdown"
         }));
@@ -2970,7 +2987,7 @@ module.exports.markdown = {
         test.done();
     },
     
-    testMarkdownFileLocalizeWithReferenceLinks: function(test) {
+    testMarkdownFileLocalizeReferenceLinksWithTitle: function(test) {
         test.expect(3);
 
         var mf = new MarkdownFile({
@@ -3014,6 +3031,58 @@ module.exports.markdown = {
             '* [Auf Twitter stellen][twitter]: Für allgemeine Fragen und Unterstützung.\n' +
             '\n' +
             '[twitter]: https://twitter.com/OurPlatform\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeReferenceLinksWithoutTitle: function(test) {
+        test.expect(3);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter] For general questions and support.\n' +
+            '\n' +
+            '[Ask on Twitter]: https://twitter.com/OurPlatform\n'
+        );
+        test.ok(mf);
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r816306377',
+            source: 'For developer support, please reach out to us via one of our channels:',
+            target: 'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r1030328207',
+            source: '<c0>Ask on Twitter</c0> For general questions and support.',
+            target: '<c0>Auf Twitter stellen</c0> Für allgemeine Fragen und Unterstützung.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        // DON'T localize the label. Instead, add a title that is translated
+        var expected =
+            'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
+            '\n' +
+            '* [Auf Twitter stellen][Ask on Twitter] Für allgemeine Fragen und Unterstützung.\n' +
+            '\n' +
+            '[Ask on Twitter]: https://twitter.com/OurPlatform\n';
 
         diff(actual, expected);
         test.equal(actual, expected);
@@ -3106,6 +3175,5 @@ module.exports.markdown = {
         test.equal(actual, expected);
 
         test.done();
-    },
-
+    }
 };

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1862,7 +1862,7 @@ module.exports.markdown = {
         }));
 
         test.equal(mf.localizeText(translations, "fr-FR"),
-            'Ceci est un test du système d\'analyse syntaxique de l\'urgence [C1].\n');
+            'Ceci est un test du système d\'analyse syntaxique de l\'urgence [C1][C1].\n');
 
         test.done();
     },
@@ -1883,13 +1883,13 @@ module.exports.markdown = {
             key: "r817759238",
             source: "This is a test of the emergency <c0>C1</c0> parsing system <c1>R1</c1>.",
             sourceLocale: "en-US",
-            target: "Ceci est un test du système d'analyse syntaxique <c1>R1</c1> de l'urgence <c0>C1</c0>.",
+            target: "Ceci est un test du système d'analyse syntaxique <c1>Reponse1</c1> de l'urgence <c0>teste</c0>.",
             targetLocale: "fr-FR",
             datatype: "markdown"
         }));
 
         test.equal(mf.localizeText(translations, "fr-FR"),
-            'Ceci est un test du système d\'analyse syntaxique [R1] de l\'urgence [C1].\n\n[C1]: https://www.box.com/test1\n\n[R1]: http://www.box.com/about.html\n');
+            'Ceci est un test du système d\'analyse syntaxique [Reponse1][R1] de l\'urgence [teste][C1].\n\n[C1]: https://www.box.com/test1\n\n[R1]: http://www.box.com/about.html\n');
 
         test.done();
     },
@@ -3069,7 +3069,7 @@ module.exports.markdown = {
             project: "foo",
             key: 'r1030328207',
             source: '<c0>Ask on Twitter</c0> For general questions and support.',
-            target: '<c0>Auf Twitter stellen</c0> Für allgemeine Fragen und Unterstützung.',
+            target: '<c0>Auf Twitter stellen</c0> für allgemeine Fragen und Unterstützung.',
             targetLocale: "de-DE",
             datatype: "markdown"
         }));
@@ -3080,7 +3080,7 @@ module.exports.markdown = {
         var expected =
             'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
             '\n' +
-            '* [Auf Twitter stellen][Ask on Twitter] Für allgemeine Fragen und Unterstützung.\n' +
+            '* [Auf Twitter stellen][Ask on Twitter] für allgemeine Fragen und Unterstützung.\n' +
             '\n' +
             '[Ask on Twitter]: https://twitter.com/OurPlatform\n';
 


### PR DESCRIPTION
Shortcut references are converted back to full so that the title of the reference can be translated to something different than the [possibly] English label of the shortcut.