### PR TITLE
Inline code notes

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -476,6 +476,7 @@ MarkdownFile.prototype._walk = function(node) {
 
         case 'inlineCode':
             node.localizable = true;
+            this._addComment("c" + this.message.componentIndex + " will be replaced with the inline code `" + node.value + "`.");
             this.message.push(node, true);
             this.message.pop();
             break;
@@ -486,7 +487,7 @@ MarkdownFile.prototype._walk = function(node) {
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {
-                    this.comment = match[1].trim();
+                    this._addComment(match[1].trim());
                 }
                 // ignore HTML comments
                 break;
@@ -689,6 +690,17 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
 /**
  * @private
  */
+MarkdownFile.prototype._addComment = function(comment) {
+    if (!this.comment) {
+        this.comment = comment;
+    } else {
+        this.comment += " " + comment;
+    }
+};
+
+/**
+ * @private
+ */
 MarkdownFile.prototype._localizeNode = function(node, message, locale, translations) {
     var match, translation;
 
@@ -780,7 +792,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 reL10NComment.lastIndex = 0;
                 match = reL10NComment.exec(node.value);
                 if (match) {
-                    this.comment = match[1].trim();
+                    this._addComment(match[1].trim());
                 }
                 // ignore HTML comments
                 break;

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ## Release Notes
 
+### 1.3.0
+
+- The plugin now adds a translator comment/note for inline code so that the
+  translator can know what the text of the self-closing components is.
+
 ### 1.2.6
 
 - Add support for shortcut and full link references

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.2.6",
+    "version": "1.3.0",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -876,7 +876,7 @@ module.exports.markdown = {
     },
 
     testMarkdownFileParseNonBreakingInlineCode: function(test) {
-        test.expect(5);
+        test.expect(6);
 
         var mf = new MarkdownFile({
             project: p
@@ -891,7 +891,30 @@ module.exports.markdown = {
         var r = set.getBySource("This is a test of the <c0/> system.");
         test.ok(r);
         test.equal(r.getSource(), "This is a test of the <c0/> system.");
+        test.equal(r.getComment(), "c0 will be replaced with the inline code `inline code`.");
         test.equal(r.getKey(), "r405516144");
+
+        test.done();
+    },
+
+    testMarkdownFileParseMultipleNonBreakingInlineCodes: function(test) {
+        test.expect(6);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a `test` of the `inline code` system.\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a <c0/> of the <c1/> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a <c0/> of the <c1/> system.");
+        test.equal(r.getComment(), "c0 will be replaced with the inline code `test`. c1 will be replaced with the inline code `inline code`.");
+        test.equal(r.getKey(), "r960448365");
 
         test.done();
     },


### PR DESCRIPTION
The plugin now adds a translator comment/note for inline code so that the translator can know what the text of the self-closing components is.