### PR TITLE
Add support for localizing links and link references.

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -222,6 +222,11 @@ MarkdownFile.prototype._addTransUnit = function(text, comment) {
  */
 function trim(API, text) {
     var i, pre = "", post = "", ret = {};
+    if (!text) {
+        return {
+            pre: ""
+        };
+    }
 
     for (i = 0; i < text.length && API.utils.isWhite(text.charAt(i)); i++);
 
@@ -451,8 +456,7 @@ MarkdownFile.prototype._walk = function(node) {
                 // only localizable if there already is some localizable text
                 // or if this text contains anything that is not whitespace
                 if (parts.text) {
-                    this.message.addText(value);
-                    this.message.isTranslatable = this.localizeLinks;
+                    this._addTransUnit(node.url);
                     node.localizable = true;
                 }
                 node.title && this._addTransUnit(node.title);
@@ -798,7 +802,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 } else {
                     message.pop();
                 }
-                
+
                 if (node.url) {
                     node.url = this._localizeString(node.url, locale, translations);
                 }

--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -445,8 +445,8 @@ MarkdownFile.prototype._walk = function(node) {
         case 'definition':
             // definitions are breaking nodes
             this._emitText();
-            if (node.text || (node.url && this.localizeLinks)) {
-                var value = node.text || node.url;
+            if (node.url && this.localizeLinks) {
+                var value = node.url;
                 var parts = trim(this.API, value);
                 // only localizable if there already is some localizable text
                 // or if this text contains anything that is not whitespace
@@ -455,6 +455,7 @@ MarkdownFile.prototype._walk = function(node) {
                     this.message.isTranslatable = this.localizeLinks;
                     node.localizable = true;
                 }
+                node.title && this._addTransUnit(node.title);
             }
             break;
 
@@ -801,8 +802,8 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 if (node.url) {
                     node.url = this._localizeString(node.url, locale, translations);
                 }
-                if (node.text) {
-                    node.text = this._localizeString(node.text, locale, translations);
+                if (node.title) {
+                    node.title = this._localizeString(node.title, locale, translations);
                 }
             }
             break;

--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -797,6 +797,13 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
                 } else {
                     message.pop();
                 }
+                
+                if (node.url) {
+                    node.url = this._localizeString(node.url, locale, translations);
+                }
+                if (node.text) {
+                    node.text = this._localizeString(node.text, locale, translations);
+                }
             }
             break;
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,52 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ## Release Notes
 
+### 1.4.0
+
+- Add support for localizing links and link references.
+
+By default, URLs are not localizable, as the majority are the same
+in all languages. Sometimes, however you want to be able to give a
+different URL for each locale. With this new features, you can turn
+on link localization.
+
+To localize a link in the text, put a localize-links directive around
+it, which is an lint-style HTML comment. Example:
+
+```markdown
+There are
+<!-- i18n-enable localize-links -->
+[fifty](http://www.example.com/)
+<!-- i18n-disable localize-links -->
+of them for sale.
+```
+
+The text "fifty" is localized along with the rest of the sentence in the
+string:
+
+```
+There are <c0>fifty</c0> of them for sale.
+```
+
+Note the c0 tags denote where the link goes. The directives, being HTML
+comments, are not included in the string to translate.
+
+The URL itself appears as a separate string to translate.
+
+Localizing a link reference is very similar. Surround the reference
+definition with a localize-links directive:
+
+```markdown
+There are [fifty][url] of them for sale.
+
+<!-- i18n-enable localize-links -->
+[url]: http://www.example.com/ "link title"
+<!-- i18n-disable localize-links -->
+```
+
+The link title for link reference definitions is included as a separate string
+to translate.
+
 ### 1.3.0
 
 - The plugin now adds a translator comment/note for inline code so that the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2261,6 +2261,40 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeTextLocalizableTitleSingleQuotes: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse("Markdown text <div title='This value is localizable'>This is a test</div>\n");
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            key: 'r922503175',
+            project: "foo",
+            source: 'This value is localizable',
+            target: 'Cette valeur est localisable',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r654479252',
+            source: 'This is a test',
+            target: 'Ceci est un essai',
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Markdown text <div title="Cette valeur est localisable">Ceci est un essai</div>\n');
+
+        test.done();
+    },
+
     testMarkdownFileLocalizeTextLocalizableAttributes: function(test) {
         test.expect(2);
 
@@ -3127,8 +3161,8 @@ module.exports.markdown = {
         test.equal(resources.length, 3);
 
         test.equal(resources[0].getSource(), "Regular service will be <c0>available</c0>.");
-        test.equal(resources[1].getSource(), "link title");
-        test.equal(resources[2].getSource(), "http://a.com/");
+        test.equal(resources[1].getSource(), "http://a.com/");
+        test.equal(resources[2].getSource(), "link title");
 
         test.done();
     },
@@ -3363,7 +3397,6 @@ module.exports.markdown = {
 
         var actual = mf.localizeText(translations, "de-DE");
 
-        // DON'T localize the label. Instead, add a title that is translated
         var expected =
             'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
             '\n' +

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -833,7 +833,7 @@ module.exports.markdown = {
     },
 
     testMarkdownFileParseTurnOnURLOnlyLinks: function(test) {
-        test.expect(7);
+        test.expect(12);
 
         var mf = new MarkdownFile({
             project: p
@@ -3067,7 +3067,7 @@ module.exports.markdown = {
     },
 
     testMarkdownFileParseWithLinkReferenceToExtractedURL: function(test) {
-        test.expect(6);
+        test.expect(8);
 
         var mf = new MarkdownFile({
             project: p
@@ -3102,7 +3102,7 @@ module.exports.markdown = {
     },
 
     testMarkdownFileParseWithLinkReferenceToExtractedURLNotAfterTurnedOff: function(test) {
-        test.expect(6);
+        test.expect(7);
 
         var mf = new MarkdownFile({
             project: p

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3101,6 +3101,38 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseWithLinkReferenceWithLinkTitle: function(test) {
+        test.expect(7);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            'Regular service will be [available][exception].\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[exception]: http://a.com/ "link title"\n' +
+            '<!-- i18n-disable localize-links -->'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 3);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 3);
+
+        test.equal(resources[0].getSource(), "Regular service will be <c0>available</c0>.");
+        test.equal(resources[1].getSource(), "link title");
+        test.equal(resources[2].getSource(), "http://a.com/");
+
+        test.done();
+    },
+
     testMarkdownFileParseWithLinkReferenceToExtractedURLNotAfterTurnedOff: function(test) {
         test.expect(7);
 
@@ -3172,7 +3204,7 @@ module.exports.markdown = {
         test.done();
     },
     
-    testMarkdownFileLocalizeReferenceLinksWithTitle: function(test) {
+    testMarkdownFileLocalizeReferenceLinksWithLinkId: function(test) {
         test.expect(3);
 
         var mf = new MarkdownFile({
@@ -3223,7 +3255,7 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileLocalizeReferenceLinksWithoutTitle: function(test) {
+    testMarkdownFileLocalizeReferenceLinksWithoutLinkId: function(test) {
         test.expect(3);
 
         var mf = new MarkdownFile({
@@ -3268,6 +3300,78 @@ module.exports.markdown = {
             '* [Auf Twitter stellen][Ask on Twitter] für allgemeine Fragen und Unterstützung.\n' +
             '\n' +
             '[Ask on Twitter]: https://twitter.com/OurPlatform\n';
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeReferenceLinksWithLinkTitle: function(test) {
+        test.expect(3);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            'For developer support, please reach out to us via one of our channels:\n' +
+            '\n' +
+            '- [Ask on Twitter][twitter] For general questions and support.\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n' +
+            '[twitter]: https://twitter.com/OurPlatform "Our Platform"\n' +
+            '<!-- i18n-disable localize-links -->\n'
+        );
+        test.ok(mf);
+
+        var translations = new TranslationSet();
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r816306377',
+            source: 'For developer support, please reach out to us via one of our channels:',
+            target: 'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r1030328207',
+            source: '<c0>Ask on Twitter</c0> For general questions and support.',
+            target: '<c0>Auf Twitter stellen</c0> für allgemeine Fragen und Unterstützung.',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r85880207',
+            source: 'https://twitter.com/OurPlatform',
+            target: 'https://de.twitter.com/OurPlatform',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: 'r504251007',
+            source: 'Our Platform',
+            target: 'Unsere Platformen',
+            targetLocale: "de-DE",
+            datatype: "markdown"
+        }));
+
+        var actual = mf.localizeText(translations, "de-DE");
+
+        // DON'T localize the label. Instead, add a title that is translated
+        var expected =
+            'Wenn Sie Entwicklerunterstützung benötigen, wenden Sie sich bitte über einen unserer Kanäle an uns:\n' +
+            '\n' +
+            '* [Auf Twitter stellen][twitter] für allgemeine Fragen und Unterstützung.\n' +
+            '\n' +
+            '<!-- i18n-enable localize-links -->\n\n' +
+            '[twitter]: https://de.twitter.com/OurPlatform "Unsere Platformen"\n\n' +
+            '<!-- i18n-disable localize-links -->\n';
 
         diff(actual, expected);
         test.equal(actual, expected);

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -2973,6 +2973,38 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseWithLinkReferenceToExtractedURL: function(test) {
+        test.expect(6);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse(
+            '- [Ask on Twitter][twitter]: For general questions and support.\n' +
+            '- [Ask on Facebook][facebook]: For general questions and support.\n' +
+            '\n' +
+            '<!-- i18n: extract-urls -->\n' +
+            '[twitter]: https://twitter.com/OurPlatform\n' +
+            '<!-- i18n: no-extract-urls -->'
+        );
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        test.equal(set.size(), 2);
+
+        var resources = set.getAll();
+
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
+        test.equal(resources[1].getSource(), "https://twitter.com/OurPlatform");
+
+        test.done();
+    },
+
     testMarkdownFileParseWithMultipleLinkReferenceWithText: function(test) {
         test.expect(8);
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -856,7 +856,7 @@ module.exports.markdown = {
         test.equal(r.getSource(), "Here are some links:");
         test.equal(r.getKey(), "r539503678");
 
-        // the URLs should not be extracted if they are the only thing in the string
+        // the URLs should be extracted because we turned on link localization
         r = set.getBySource("http://www.box.com/foobar");
         test.ok(r);
         test.equal(r.getSource(), "http://www.box.com/foobar");

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -842,10 +842,10 @@ module.exports.markdown = {
 
         mf.parse(
             'Here are some links:\n\n' +
-            '<-- i18n-enable localize-links -->\n' +
+            '<!-- i18n-enable localize-links -->\n' +
             '* [http://www.box.com/foobar](http://www.box.com/foobar)\n' +
             '* [http://www.box.com/asdf](http://www.box.com/asdf)\n' +
-            '<-- i18n-disable localize-links -->\n');
+            '<!-- i18n-disable localize-links -->\n');
 
         var set = mf.getTranslationSet();
         test.ok(set);
@@ -3087,15 +3087,16 @@ module.exports.markdown = {
         var set = mf.getTranslationSet();
         test.ok(set);
 
-        test.equal(set.size(), 3);
+        test.equal(set.size(), 4);
 
         var resources = set.getAll();
 
-        test.equal(resources.length, 3);
+        test.equal(resources.length, 4);
 
         test.equal(resources[0].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
-        test.equal(resources[1].getSource(), "https://twitter.com/OurPlatform");
-        test.equal(resources[2].getSource(), "http://www.facebook.com/OurPlatform");
+        test.equal(resources[1].getSource(), "<c0>Ask on Facebook</c0>: For general questions and support.");
+        test.equal(resources[2].getSource(), "https://twitter.com/OurPlatform");
+        test.equal(resources[3].getSource(), "http://www.facebook.com/OurPlatform");
 
         test.done();
     },
@@ -3121,14 +3122,15 @@ module.exports.markdown = {
         var set = mf.getTranslationSet();
         test.ok(set);
 
-        test.equal(set.size(), 2);
+        test.equal(set.size(), 3);
 
         var resources = set.getAll();
 
-        test.equal(resources.length, 2);
+        test.equal(resources.length, 3);
 
         test.equal(resources[0].getSource(), "<c0>Ask on Twitter</c0>: For general questions and support.");
-        test.equal(resources[1].getSource(), "https://twitter.com/OurPlatform");
+        test.equal(resources[1].getSource(), "<c0>Ask on Facebook</c0>: For general questions and support.");
+        test.equal(resources[2].getSource(), "https://twitter.com/OurPlatform");
 
         test.done();
     },


### PR DESCRIPTION
By default, URLs are not localizable, as the majority are the same
in all languages. Sometimes, however you want to be able to give a
different URL for each locale. With this new features, you can turn
on link localization.

To localize a link in the text, put a localize-links directive around
it, which is an lint-style HTML comment. Example:

```markdown
There are
<!-- i18n-enable localize-links -->
[fifty](http://www.example.com/)
<!-- i18n-disable localize-links -->
of them for sale.
```

The text "fifty" is localized along with the rest of the sentence in the
string:

```
There are <c0>fifty</c0> of them for sale.
```

Note the c0 tags denote where the link goes. The directives, being HTML
comments, are not included in the string to translate.

The URL itself appears as a separate string to translate.

Localizing a link reference is very similar. Surround the reference
definition with a localize-links directive:

```markdown
There are [fifty][url] of them for sale.

<!-- i18n-enable localize-links -->
[url]: http://www.example.com/ "link title"
<!-- i18n-disable localize-links -->
```

The link title for link reference definitions is included as a separate string
to translate.