### PR TITLE
Add the ability to only localize a markdown file if it is fully translated

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: node_js
+node_js:
+  - "8"
+  - "9"
+  - "10"
+  - "11"
+  - "12"
+  - "13"
+  - "14"
+install:
+  - rm -rf node_modules
+  - npm install
+  - export PATH=$PWD/node_modules/.bin:$PATH
+script:
+  - npm run clean
+  - npm run test
+branches:
+  only:
+    - master
+dist: trusty

--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -21,6 +21,7 @@ var fs = require("fs");
 var path = require("path");
 var log4js = require("log4js");
 var MessageAccumulator = require("message-accumulator").default;
+var Node = require("ilib-tree-node").default;
 var Locale = require("ilib/lib/Locale.js");
 var isAlnum = require("ilib/lib/isAlnum.js");
 var isIdeo = require("ilib/lib/isIdeo.js");
@@ -128,6 +129,10 @@ var MarkdownFile = function(options) {
     this.set = this.API.newTranslationSet(this.project ? this.project.sourceLocale : "zxx-XX");
     this.localizeLinks = false;
     // this.componentIndex = 0;
+    // if this is set, only produce fully translated markdown files. Otherwise if they
+    // are not fully translated, just output the original source text.
+    this.fullyTranslated = this.project && this.project.settings && this.project.settings.markdown && this.project.settings.markdown.fullyTranslated;
+    this.translationStatus = {};
 };
 
 /**
@@ -722,6 +727,7 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
                 datatype: "markdown",
                 index: this.resourceIndex++
             }));
+            this.translationStatus[locale] = false; // mark this file as not fully translated in this locale
 
             translation = source;
 
@@ -731,6 +737,7 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
         }
     } else {
         translation = source;
+        this.translationStatus[locale] = false; // mark this file as not fully translated in this locale
     }
 
     return translation;
@@ -819,6 +826,9 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
             if (node.localizable) {
                 if (node.use === "start") {
                     message.push(node);
+                } else if (node.use === "startend") {
+                    message.push(node, true);
+                    message.pop();
                 } else {
                     message.pop();
                 }
@@ -1042,6 +1052,8 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
 
     var start = -1, end, ma = new MessageAccumulator();
 
+    this.translationStatus[locale] = true;
+
     for (var i = 0; i < nodeArray.length; i++) {
         this._localizeNode(nodeArray[i], ma, locale, translations);
 
@@ -1082,7 +1094,7 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
     // convert to a tree again
     ast = mapToAst(Node.fromArray(nodeArray));
 
-    var str = mdstringify.stringify(ast);
+    var str = mdstringify.stringify((!this.fullyTranslated || this.translationStatus[locale]) ? ast : this.ast);
 
     // make sure the thematic breaks don't have blank lines after them and they
     // don't erroneously escape the backslash chars
@@ -1102,12 +1114,14 @@ MarkdownFile.prototype.localizeText = function(translations, locale) {
  * @param {Array.<String>} locales array of locales to translate to
  */
 MarkdownFile.prototype.localize = function(translations, locales) {
+    var pathName;
     for (var i = 0; i < locales.length; i++) {
         if (!this.project.isSourceLocale(locales[i])) {
             // skip variants for now until we can handle them properly
             var l = new Locale(locales[i]);
+            pathName = "";
             if (!l.getVariant()) {
-                var pathName = this.getLocalizedPath(locales[i]);
+                pathName = this.getLocalizedPath(locales[i]);
                 logger.debug("Writing file " + pathName);
                 var p = path.join(this.project.target, pathName);
                 var d = path.dirname(p);
@@ -1115,6 +1129,12 @@ MarkdownFile.prototype.localize = function(translations, locales) {
 
                 fs.writeFileSync(p, this.localizeText(translations, locales[i]), "utf-8");
             }
+
+            this.type.addTranslationStatus({
+                path: pathName,
+                locale: locales[i],
+                fullyTranslated: this.translationStatus[locales[i]]
+            });
         }
     }
 };

--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -280,7 +280,10 @@ MarkdownFile.prototype.isTranslatable = function(str) {
  * @private
  */
 MarkdownFile.prototype._emitText = function(escape) {
-    if (!this.message.getTextLength()) return;
+    if (!this.message.getTextLength()) {
+        this.message = new MessageAccumulator();
+        return;
+    }
 
     var text = this.message.getMinimalString();
 

--- a/MarkdownFileType.js
+++ b/MarkdownFileType.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 
+var fs = require("fs");
 var path = require("path");
 var log4js = require("log4js");
 
@@ -49,6 +50,11 @@ var MarkdownFileType = function(project) {
     // for use with missing strings
     if (!project.settings.nopseudo) {
         this.missingPseudo = this.API.getPseudoBundle(project.pseudoLocale, this, project);
+    }
+
+    this.fileInfo = {
+        translated: [],
+        untranslated: []
     }
 };
 
@@ -164,6 +170,19 @@ MarkdownFileType.prototype.getNew = function() {
  */
 MarkdownFileType.prototype.getPseudo = function() {
     return this.pseudo;
+};
+
+MarkdownFileType.prototype.addTranslationStatus = function(fileInfo) {
+    if (fileInfo.fullyTranslated) {
+        this.fileInfo.translated.push(fileInfo.path);
+    } else {
+        this.fileInfo.untranslated.push(fileInfo.path);
+    }
+};
+
+MarkdownFileType.prototype.projectClose = function() {
+    var fileName = path.join(this.project.root, "translation-status.json");
+    fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
 };
 
 module.exports = MarkdownFileType;

--- a/MarkdownFileType.js
+++ b/MarkdownFileType.js
@@ -181,8 +181,10 @@ MarkdownFileType.prototype.addTranslationStatus = function(fileInfo) {
 };
 
 MarkdownFileType.prototype.projectClose = function() {
-    var fileName = path.join(this.project.root, "translation-status.json");
-    fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
+    if (this.project.settings && this.project.settings.markdown && this.project.settings.markdown.fullyTranslated) {
+        var fileName = path.join(this.project.root, "translation-status.json");
+        fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
+    }
 };
 
 module.exports = MarkdownFileType;

--- a/README.md
+++ b/README.md
@@ -6,14 +6,11 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ### 1.5.0
 
-- added a "fullyTranslated" setting for the markdown code. This makes sure
+* added a "fullyTranslated" setting for the markdown code. This makes sure
   that if a file does not have all of its translations, then that file is
   produced in the source language.
-    - Also produces a file in the project root called `translation-status.json`
+    * Also produces a file in the project root called `translation-status.json`
       that details which files were fully translated and which were not
-
-### 1.4.2
-
 * Fixed a bug where markdown tables were not handled properly
 * Fixed a bug where inline code was not handled properly if it was the
 only thing in the localizable segment. Inline code should only be

--- a/README.md
+++ b/README.md
@@ -4,6 +4,14 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ## Release Notes
 
+### 1.5.0
+
+- added a "fullyTranslated" setting for the markdown code. This makes sure
+  that if a file does not have all of its translations, then that file is
+  produced in the source language.
+    - Also produces a file in the project root called `translation-status.json`
+      that details which files were fully translated and which were not
+
 ### 1.4.2
 
 * Fixed a bug where markdown tables were not handled properly

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Ilib loctool plugin to parse and localize github-flavored markdown
 
 ## Release Notes
 
+### 1.4.2
+
+* Fixed a bug where markdown tables were not handled properly
+* Fixed a bug where inline code was not handled properly if it was the
+only thing in the localizable segment. Inline code should only be
+localized if it is in the middle of or adjacent to localizable text.
+
 ### 1.4.1
 
 * Fixed a bug where self-closed tags like <br/> in markdown files were not handled properly,

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
         "unist-util-filter": "^1.0.2"
     },
     "devDependencies": {
-        "loctool": "^2.7.1",
+        "loctool": "^2.8.1",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.4.1",
+    "version": "1.4.2",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",
@@ -69,7 +69,7 @@
         "unist-util-filter": "^1.0.2"
     },
     "devDependencies": {
-        "loctool": "^2.4.0",
+        "loctool": "^2.7.1",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.4.2",
+    "version": "1.5.0",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -513,45 +513,6 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileParseSkipHeader: function(test) {
-        test.expect(3);
-
-        var mf = new MarkdownFile({
-            project: p
-        });
-        test.ok(mf);
-
-        mf.parse('---\ntitle: "foo"\nexcerpt: ""\n---\n');
-
-        var set = mf.getTranslationSet();
-        test.ok(set);
-        test.equal(set.size(), 0);
-
-        test.done();
-    },
-
-    testMarkdownFileParseSkipHeaderAndParseRest: function(test) {
-        test.expect(6);
-
-        var mf = new MarkdownFile({
-            project: p
-        });
-        test.ok(mf);
-
-        mf.parse('---\ntitle: "foo"\nexcerpt: ""\n---\n\nThis is a test\n');
-
-        var set = mf.getTranslationSet();
-        test.ok(set);
-        test.equal(set.size(), 1);
-
-        var r = set.getBySource("This is a test");
-        test.ok(r);
-        test.equal(r.getSource(), "This is a test");
-        test.equal(r.getKey(), "r654479252");
-
-        test.done();
-    },
-
     testMarkdownFileParseNoStrings: function(test) {
         test.expect(3);
 
@@ -710,52 +671,6 @@ module.exports.markdown = {
         test.ok(r);
         test.equal(r.getSource(), "This is also a \u000C test");
         test.equal(r.getKey(), "r999080996");
-
-        test.done();
-    },
-
-    testMarkdownFileSkipReadmeIOBlocks: function(test) {
-        test.expect(8);
-
-        var mf = new MarkdownFile({
-            project: p
-        });
-        test.ok(mf);
-
-        mf.parse('This is a test\n' +
-                  '[block:parameters]\n' +
-                  '{\n' +
-                  '  "data": {\n' +
-                  '      "h-0": "Parameter",\n' +
-                  '      "h-1": "Description",\n' +
-                  '      "0-0": "**response_type**",\n' +
-                  '      "1-0": "**client_id**",\n' +
-                  '      "2-0": "**redirect_uri**",\n' +
-                  '      "3-0": "**state**",\n' +
-                  '      "4-0": "**scope** *optional*",\n' +
-                  '      "0-1": "String",\n' +
-                  '      "1-1": "String",\n' +
-                  '      "2-1": "URI"\n' +
-                  '  }\n' +
-                  '}\n' +
-                  '[/block]\n' +
-                  'bar\n');
-
-        var set = mf.getTranslationSet();
-        test.ok(set);
-
-        var r = set.getBySource("This is a test");
-        test.ok(r);
-        test.equal(r.getSource(), "This is a test");
-        test.equal(r.getKey(), "r654479252");
-
-        var r = set.getBySource("Description");
-        test.ok(!r);
-
-        var r = set.getBySource("bar");
-        test.ok(r);
-
-        test.equal(set.size(), 2);
 
         test.done();
     },
@@ -3472,63 +3387,6 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileLocalizeTextWithListAndBlockWithNoSpace: function(test) {
-        test.expect(2);
-
-        var mf = new MarkdownFile({
-            project: p
-        });
-        test.ok(mf);
-
-        mf.parse(
-            '* list item 1\n' +
-            '* list item 2\n' +
-            '[block:callout]\n' +
-            '{\n' +
-            '  "type": "test"\n' +
-            '}\n' +
-            '[/block]\n' +
-            '## Test Header\n');
-
-        var translations = new TranslationSet();
-        translations.add(new ResourceString({
-            project: "foo",
-            key: 'r970090275',
-            source: 'list item 1',
-            target: 'article du liste No. 1',
-            targetLocale: "fr-FR",
-            datatype: "markdown"
-        }));
-        translations.add(new ResourceString({
-            project: "foo",
-            key: 'r970155796',
-            source: 'list item 2',
-            target: 'article du liste No. 2',
-            targetLocale: "fr-FR",
-            datatype: "markdown"
-        }));
-        translations.add(new ResourceString({
-            project: "foo",
-            key: 'r34696891',
-            source: 'Test Header',
-            target: 'Entête du Teste',
-            targetLocale: "fr-FR",
-            datatype: "markdown"
-        }));
-
-        test.equal(mf.localizeText(translations, "fr-FR"),
-            '* article du liste No. 1\n' +
-            '* article du liste No. 2\n\n' +
-            '[block:callout]\n' +
-            '{\n' +
-            '  "type": "test"\n' +
-            '}\n' +
-            '[/block]\n\n' +
-            '## Entête du Teste\n');
-
-        test.done();
-    },
-
     testMarkdownFileLocalizeTextHeaderWithNoSpace: function(test) {
         test.expect(2);
 
@@ -3564,60 +3422,6 @@ module.exports.markdown = {
             '# Entête mal\n\n' +
             '## Autre entête mal\n\n' +
             '# Entête mal\n');
-
-        test.done();
-    },
-
-    testMarkdownFileLocalizeTextDontEscapeCode: function(test) {
-        test.expect(2);
-
-        var mf = new MarkdownFile({
-            project: p
-        });
-        test.ok(mf);
-
-        mf.parse(
-            'test\n' +
-            '[block:code]\n' +
-            '{\n' +
-            '  "codes": [\n' +
-            '    {\n' +
-            '      "code": "aws cloudformation describe-stacks \\\\\\n    --stack-name boxskill \\\\\\n    --query \'Stacks[].Outputs\'\\n# Your URL should look something like this:\\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
-            '      "language": "shell"\n' +
-            '    }\n' +
-            '  ]\n' +
-            '}\n' +
-            '[/block]\n' +
-            'test\n');
-
-        var translations = new TranslationSet();
-        translations.add(new ResourceString({
-            project: "foo",
-            key: 'r852587715',
-            source: 'test',
-            target: 'Teste',
-            targetLocale: "fr-FR",
-            datatype: "markdown"
-        }));
-
-        var actual = mf.localizeText(translations, "fr-FR");
-        var expected =
-            'Teste\n\n' +
-            '[block:code]\n' +
-            '{\n' +
-            '  "codes": [\n' +
-            '    {\n' +
-            '      "code": "aws cloudformation describe-stacks \\\\\\n    --stack-name boxskill \\\\\\n    --query \'Stacks[].Outputs\'\\n# Your URL should look something like this:\\n# https://[id].execute-api.us-east-1.amazonaws.com/Prod/hello/",\n' +
-            '      "language": "shell"\n' +
-            '    }\n' +
-            '  ]\n' +
-            '}\n' +
-            '[/block]\n\n' +
-            'Teste\n';
-
-        diff(actual, expected);
-
-        test.equal(actual, expected);
 
         test.done();
     },

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3214,10 +3214,10 @@ module.exports.markdown = {
 
         mf.localize(translations, ["fr-FR", "de-DE"]);
 
-        test.ok(fs.existsSync(path.join(p.root, "fr-FR/md/test1.md")));
-        test.ok(fs.existsSync(path.join(p.root, "de-DE/md/test1.md")));
+        test.ok(fs.existsSync(path.join(p.target, "fr-FR/md/test1.md")));
+        test.ok(fs.existsSync(path.join(p.target, "de-DE/md/test1.md")));
 
-        var content = fs.readFileSync(path.join(p.root, "fr-FR/md/test1.md"), "utf-8");
+        var content = fs.readFileSync(path.join(p.target, "fr-FR/md/test1.md"), "utf-8");
 
         var expected =
             '# Ceci est le titre de ce document de teste qui apparaît plusiers fois dans le document lui-même.\n' +
@@ -3231,7 +3231,7 @@ module.exports.markdown = {
         diff(content, expected);
         test.equal(content, expected);
 
-        var content = fs.readFileSync(path.join(p.root, "de-DE/md/test1.md"), "utf-8");
+        var content = fs.readFileSync(path.join(p.target, "de-DE/md/test1.md"), "utf-8");
 
         var expected =
             '# Dies ist der Titel dieses Testdokumentes, das mehrmals im Dokument selbst erscheint.\n' +
@@ -3332,10 +3332,10 @@ module.exports.markdown = {
 
         mf.localize(translations, ["fr-FR", "de-DE"]);
 
-        test.ok(fs.existsSync(path.join(p.root, "fr-FR/md/test3.md")));
-        test.ok(fs.existsSync(path.join(p.root, "de-DE/md/test3.md")));
+        test.ok(fs.existsSync(path.join(p.target, "fr-FR/md/test3.md")));
+        test.ok(fs.existsSync(path.join(p.target, "de-DE/md/test3.md")));
 
-        var content = fs.readFileSync(path.join(p.root, "fr-FR/md/test3.md"), "utf-8");
+        var content = fs.readFileSync(path.join(p.target, "fr-FR/md/test3.md"), "utf-8");
 
         var expected =
             '---\n' +
@@ -3353,7 +3353,7 @@ module.exports.markdown = {
         diff(content, expected);
         test.equal(content, expected);
 
-        var content = fs.readFileSync(path.join(p.root, "de-DE/md/test3.md"), "utf-8");
+        var content = fs.readFileSync(path.join(p.target, "de-DE/md/test3.md"), "utf-8");
 
         var expected =
             '---\n' +
@@ -3410,8 +3410,8 @@ module.exports.markdown = {
         mf.localize(translations, ["fr-FR", "de-DE"]);
 
         // should produce the files, even if there is nothing to localize in them
-        test.ok(fs.existsSync(path.join(p.root, "fr-FR/md/nostrings.md")));
-        test.ok(fs.existsSync(path.join(p.root, "de-DE/md/nostrings.md")));
+        test.ok(fs.existsSync(path.join(p.target, "fr-FR/md/nostrings.md")));
+        test.ok(fs.existsSync(path.join(p.target, "de-DE/md/nostrings.md")));
 
         test.done();
     },

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -4188,7 +4188,11 @@ module.exports.markdown = {
         test.expect(3);
 
         // this subproject has the "fullyTranslated" flag set to true
-        var p2 = ProjectFactory("./test/testfiles/subproject", {});
+        var p2 = ProjectFactory("./test/testfiles/subproject", {
+            markdown: {
+                fullyTranslated: true
+            }
+        });
         var mdft2 = new MarkdownFileType(p2);
         var mf = new MarkdownFile({
             project: p2,
@@ -4258,7 +4262,11 @@ module.exports.markdown = {
         test.expect(3);
 
         // this subproject has the "fullyTranslated" flag set to true
-        var p2 = ProjectFactory("./test/testfiles/subproject", {});
+        var p2 = ProjectFactory("./test/testfiles/subproject", {
+            markdown: {
+                fullyTranslated: true
+            }
+        });
         var mdft2 = new MarkdownFileType(p2);
         var mf = new MarkdownFile({
             project: p2,
@@ -4296,7 +4304,11 @@ module.exports.markdown = {
         test.expect(3);
 
         // this subproject has the "fullyTranslated" flag set to true
-        var p2 = ProjectFactory("./test/testfiles/subproject", {});
+        var p2 = ProjectFactory("./test/testfiles/subproject", {
+            markdown: {
+                fullyTranslated: true
+            }
+        });
         var mdft2 = new MarkdownFileType(p2);
         var mf = new MarkdownFile({
             project: p2,

--- a/test/testMarkdownFileType.js
+++ b/test/testMarkdownFileType.js
@@ -36,7 +36,10 @@ var p2 = new CustomProject({
     sourceLocale: "en-US"
 }, "./test/testfiles", {
     locales:["en-GB"],
-    flavors: ["ASDF"]
+    flavors: ["ASDF"],
+    markdown: {
+        fullyTranslated: true
+    }
 });
 
 module.exports.markdownfiletype = {
@@ -217,10 +220,14 @@ module.exports.markdownfiletype = {
         test.done();
     },
 
-    testMarkdownFileTypeProjectClose: function(test) {
+    testMarkdownFileTypeProjectCloseFullyTranslatedOn: function(test) {
         test.expect(3);
 
-        var p2 = ProjectFactory("./test/testfiles/subproject", {});
+        var p2 = ProjectFactory("./test/testfiles/subproject", {
+            markdown: {
+                fullyTranslated: true
+            }
+        });
 
         var mdft = new MarkdownFileType(p2);
         test.ok(mdft);
@@ -258,6 +265,37 @@ module.exports.markdownfiletype = {
         };
 
         test.deepEqual(actual, expected);
+
+        test.done();
+    },
+
+    testMarkdownFileTypeProjectCloseFullyTranslatedOff: function(test) {
+        test.expect(3);
+
+        // clean up first
+        fs.unlinkSync("./test/testfiles/subproject/translation-status.json");
+        test.ok(!fs.existsSync("./test/testfiles/subproject/translation-status.json"));
+
+        var p2 = ProjectFactory("./test/testfiles/subproject", {});
+
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
+
+        var statii = [
+            {path: "fr-FR/a/b/c.md", locale: "fr-FR", fullyTranslated: false},
+            {path: "de-DE/a/b/c.md", locale: "de-DE", fullyTranslated: true},
+            {path: "ja-JP/a/b/c.md", locale: "ja-JP", fullyTranslated: false},
+            {path: "fr-FR/x/y.md", locale: "fr-FR", fullyTranslated: true},
+            {path: "de-DE/x/y.md", locale: "de-DE", fullyTranslated: false},
+            {path: "ja-JP/x/y.md", locale: "ja-JP", fullyTranslated: true}
+        ];
+        statii.forEach(function(status) {
+            mdft.addTranslationStatus(status);
+        });
+
+        mdft.projectClose();
+
+        test.ok(!fs.existsSync("./test/testfiles/subproject/translation-status.json"));
 
         test.done();
     }

--- a/test/testMarkdownFileType.js
+++ b/test/testMarkdownFileType.js
@@ -1,7 +1,7 @@
 /*
  * testMarkdownFileType.js - test the Markdown file type handler object.
  *
- * Copyright © 2019, Box, Inc.
+ * Copyright © 2019-2020, Box, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,12 @@
  * limitations under the License.
  */
 
+var fs = require("fs");
+
 if (!MarkdownFileType) {
     var MarkdownFileType = require("../MarkdownFileType.js");
     var CustomProject =  require("loctool/lib/CustomProject.js");
+    var ProjectFactory =  require("loctool/lib/ProjectFactory.js");
 }
 
 var p = new CustomProject({
@@ -40,9 +43,9 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeConstructor: function(test) {
         test.expect(1);
 
-        var htf = new MarkdownFileType(p);
+        var mdft = new MarkdownFileType(p);
 
-        test.ok(htf);
+        test.ok(mdft);
 
         test.done();
     },
@@ -50,10 +53,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesMD: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.md"));
+        test.ok(mdft.handles("foo.md"));
 
         test.done();
     },
@@ -61,10 +64,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesMarkdown: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.markdown"));
+        test.ok(mdft.handles("foo.markdown"));
 
         test.done();
     },
@@ -72,10 +75,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesMdown: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.mdown"));
+        test.ok(mdft.handles("foo.mdown"));
 
         test.done();
     },
@@ -83,10 +86,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesMkd: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.mkd"));
+        test.ok(mdft.handles("foo.mkd"));
 
         test.done();
     },
@@ -94,10 +97,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesRst: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.rst"));
+        test.ok(mdft.handles("foo.rst"));
 
         test.done();
     },
@@ -105,10 +108,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesRmd: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("foo.rmd"));
+        test.ok(mdft.handles("foo.rmd"));
 
         test.done();
     },
@@ -116,10 +119,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesFalseClose: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("foo.tml"));
+        test.ok(!mdft.handles("foo.tml"));
 
         test.done();
     },
@@ -127,10 +130,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesTrueWithDir: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(htf.handles("a/b/c/foo.md"));
+        test.ok(mdft.handles("a/b/c/foo.md"));
 
         test.done();
     },
@@ -138,10 +141,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesAlreadyLocalizedGB: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("en-GB/a/b/c/foo.md"));
+        test.ok(!mdft.handles("en-GB/a/b/c/foo.md"));
 
         test.done();
     },
@@ -149,10 +152,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesAlreadyLocalizedCN: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("zh-Hans-CN/a/b/c/foo.md"));
+        test.ok(!mdft.handles("zh-Hans-CN/a/b/c/foo.md"));
 
         test.done();
     },
@@ -160,10 +163,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesAlreadyLocalizedWithFlavor: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p2);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("en-ZA-ASDF/a/b/c/foo.md"));
+        test.ok(!mdft.handles("en-ZA-ASDF/a/b/c/foo.md"));
 
         test.done();
     },
@@ -171,10 +174,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandleszhHKAlreadyLocalizedWithFlavor: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p2);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
 
-        test.ok(!htf.handles("zh-Hant-HK-ASDF/a/b/c/foo.md"));
+        test.ok(!mdft.handles("zh-Hant-HK-ASDF/a/b/c/foo.md"));
 
         test.done();
     },
@@ -182,10 +185,10 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesSourceDirIsNotLocalized: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p2);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
 
-        test.ok(htf.handles("en-US/a/b/c/foo.md"));
+        test.ok(mdft.handles("en-US/a/b/c/foo.md"));
 
         test.done();
     },
@@ -193,11 +196,11 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesSourceDirNotLocalizedWithMD: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p2);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
 
         // md has the form of an iso language name, but it is not a real language
-        test.ok(htf.handles("md/a/b/c/foo.md"));
+        test.ok(mdft.handles("md/a/b/c/foo.md"));
 
         test.done();
     },
@@ -205,12 +208,58 @@ module.exports.markdownfiletype = {
     testMarkdownFileTypeHandlesSourceDirNotLocalizedWithLocaleLookingDir: function(test) {
         test.expect(2);
 
-        var htf = new MarkdownFileType(p2);
-        test.ok(htf);
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
 
         // en-AA looks like a real locale, but it is not because XX is not a country code
-        test.ok(htf.handles("en-XX/a/b/c/foo.md"));
+        test.ok(mdft.handles("en-XX/a/b/c/foo.md"));
+
+        test.done();
+    },
+
+    testMarkdownFileTypeProjectClose: function(test) {
+        test.expect(3);
+
+        var p2 = ProjectFactory("./test/testfiles/subproject", {});
+
+        var mdft = new MarkdownFileType(p2);
+        test.ok(mdft);
+
+        var statii = [
+            {path: "fr-FR/a/b/c.md", locale: "fr-FR", fullyTranslated: false},
+            {path: "de-DE/a/b/c.md", locale: "de-DE", fullyTranslated: true},
+            {path: "ja-JP/a/b/c.md", locale: "ja-JP", fullyTranslated: false},
+            {path: "fr-FR/x/y.md", locale: "fr-FR", fullyTranslated: true},
+            {path: "de-DE/x/y.md", locale: "de-DE", fullyTranslated: false},
+            {path: "ja-JP/x/y.md", locale: "ja-JP", fullyTranslated: true}
+        ];
+        statii.forEach(function(status) {
+            mdft.addTranslationStatus(status);
+        });
+
+        mdft.projectClose();
+
+        test.ok(fs.existsSync("./test/testfiles/subproject/translation-status.json"));
+
+        var contents = fs.readFileSync("./test/testfiles/subproject/translation-status.json", "utf-8");
+        var actual = JSON.parse(contents);
+
+        var expected = {
+            translated: [
+                "de-DE/a/b/c.md",
+                "fr-FR/x/y.md",
+                "ja-JP/x/y.md"
+            ],
+            untranslated: [
+                "fr-FR/a/b/c.md",
+                "ja-JP/a/b/c.md",
+                "de-DE/x/y.md"
+            ]
+        };
+
+        test.deepEqual(actual, expected);
 
         test.done();
     }
+
 };

--- a/test/testfiles/subproject/notrans.md
+++ b/test/testfiles/subproject/notrans.md
@@ -1,0 +1,10 @@
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+==================================
+
+This is some text. This is more text. Pretty, pretty text.
+
+This is localizable text. This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.
+
+This is the last bit of localizable text.
+
+This is the TITLE of this Test Document Which Appears Several Times Within the Document Itself.

--- a/test/testfiles/subproject/project.json
+++ b/test/testfiles/subproject/project.json
@@ -1,0 +1,22 @@
+{
+    "name": "Loctool Test",
+    "id": "loctest2",
+    "projectType": "custom",
+    "pseudoLocale": "de-DE",
+    "resourceDirs": {
+        "yml": "config/locales",
+        "js": "public/localized_js"
+    },
+    "schema": "./appinfo.schema.json",
+    "excludes": [
+    ],
+    "includes": [
+        "config/notifications.yml"
+    ],
+    "settings": {
+        "locales": ["en-GB", "es-US", "zh-Hans-CN"],
+        "markdown": {
+            "fullyTranslated": true
+        }
+    }
+}

--- a/test/testfiles/subproject/project.json
+++ b/test/testfiles/subproject/project.json
@@ -14,9 +14,6 @@
         "config/notifications.yml"
     ],
     "settings": {
-        "locales": ["en-GB", "es-US", "zh-Hans-CN"],
-        "markdown": {
-            "fullyTranslated": true
-        }
+        "locales": ["en-GB", "es-US", "zh-Hans-CN"]
     }
 }


### PR DESCRIPTION
Change copied from the loctool main code.

- if it is not fully translated, the entire file will be produced in the source language instead. (ie. it is a copy of the original source file)
- add a setting in project.json to turn this on:
```json
"settings": {
  "markdown": {
    "fullyTranslated": true
  }
}
```
- the markdown code now produces a file in the project root called "translation-status.json" which documents which md files were fully translated and which were not:
```json
{
  "translated": [
    "array of path names ..."
  ],
  "untranslated": [
    "array of path names ..."
  ]
}
```