### PR TITLE
Add support for footnotes

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -830,7 +830,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
         case 'footnoteReference':
             // footnote references are non-breaking, self-closing nodes
             if (node.localizable) {
-                message.push(node);
+                message.push(node, true);
                 message.pop();
             }
             break;

--- a/package.json
+++ b/package.json
@@ -54,12 +54,13 @@
     },
     "dependencies": {
         "he": "^1.2.0",
-        "ilib": "^14.4.0",
+        "ilib": "^14.8.0",
         "log4js": "^5.3.0",
         "message-accumulator": "^2.2.1",
-        "rehype-raw": "^4.0.1",
-        "remark-frontmatter": "^1.3.2",
-        "remark-highlight.js": "^5.1.1",
+        "rehype-raw": "^4.0.2",
+        "remark-footnotes": "^2.0.0",
+        "remark-frontmatter": "^1.3.3",
+        "remark-highlight.js": "^5.2.0",
         "remark-parse": "^6.0.3",
         "remark-rehype": "^4.0.1",
         "remark-stringify": "^6.0.4",
@@ -68,7 +69,7 @@
         "unist-util-filter": "^1.0.2"
     },
     "devDependencies": {
-        "loctool": "^2.10.1",
+        "loctool": "^2.9.0",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -954,6 +954,60 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseFootnotes: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [^1] system.\n\n' +
+                '[^1]: well, not really\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing <c0/> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0/> system.");
+        test.equal(r.getKey(), "r1010312382");
+
+        var r = set.getBySource("well, not really");
+        test.ok(r);
+        test.equal(r.getSource(), "well, not really");
+        test.equal(r.getKey(), "r472274968");
+
+        test.done();
+    },
+
+    testMarkdownFileParseFootnotesLongname: function(test) {
+        test.expect(8);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [^longname] system.\n\n' +
+                '[^longname]: well, not really\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test of the emergency parsing <c0/> system.");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the emergency parsing <c0/> system.");
+        test.equal(r.getKey(), "r1010312382");
+
+        var r = set.getBySource("well, not really");
+        test.ok(r);
+        test.equal(r.getSource(), "well, not really");
+        test.equal(r.getKey(), "r472274968");
+
+        test.done();
+    },
+
     testMarkdownFileParseNonBreakingInlineCode: function(test) {
         test.expect(6);
 
@@ -2362,6 +2416,84 @@ module.exports.markdown = {
             '[C1]: https://www.box.com/fr/test1\n\n' +
             '[R1]: http://www.box.com/fr/about.html\n\n' +
             '<!-- i18n-disable localize-links -->\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithFootnotes: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [^1] system.\n\n' +
+            '[^1]: well, not really\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r1010312382",
+            source: "This is a test of the emergency parsing <c0/> system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique <c0/> de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r472274968",
+            source: "well, not really",
+            sourceLocale: "en-US",
+            target: "normalement, c'est pas vrai",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique [^1] de l\'urgence.\n\n' +
+            '[^1]: normalement, c\'est pas vrai\n');
+
+        test.done();
+    },
+
+    testMarkdownFileLocalizeTextWithFootnotesLongName: function(test) {
+        test.expect(2);
+
+        var mf = new MarkdownFile({
+            project: p
+        });
+        test.ok(mf);
+
+        mf.parse('This is a test of the emergency parsing [^longname] system.\n\n' +
+            '[^longname]: well, not really\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r1010312382",
+            source: "This is a test of the emergency parsing <c0/> system.",
+            sourceLocale: "en-US",
+            target: "Ceci est un test du système d'analyse syntaxique <c0/> de l'urgence.",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r472274968",
+            source: "well, not really",
+            sourceLocale: "en-US",
+            target: "normalement, c'est pas vrai",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+
+        test.equal(mf.localizeText(translations, "fr-FR"),
+            'Ceci est un test du système d\'analyse syntaxique [^longname] de l\'urgence.\n\n' +
+            '[^longname]: normalement, c\'est pas vrai\n');
 
         test.done();
     },


### PR DESCRIPTION
Add support for footnotes:

```
This is a footnote[^1] reference.

[^1]: a fake one, but hey, who's counting?
```

The footnote becomes a self-closing tag in the translatable string, and the text of the footnote becomes a separate translatable string.