### PR TITLE
Add support for localizing frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ This plugin now supports mappings:
     "markdown": {
       "mappings": {
         "**/foobar.md": {
-          "template": "[dir]/[base]_[locale].[extension]"
+          "template": "[dir]/[base]_[locale].[extension]",
+          "frontmatter": ["Title", "Description"]
         }
       }
     }
@@ -21,12 +22,22 @@ This plugin now supports mappings:
 }
 ```
 
-The mappings allow you to match a particular path name and apply an output
-path name template. The mappings are minimatch style.
+The mappings allow you to match a particular path name and apply particular
+settings to that path, such as an output path name template. The mappings are
+minimatch style.
 
 The template follows the syntax for path name templates defined in the
 the [loctool](https://github.com/iLib-js/loctool/blob/development/lib/utils.js#L1881)
 itself.
+
+The frontmatter setting specifies an array of strings that represent the names
+of the fields in the frontmatter that should be localized. The frontmatter is
+parsed as a yaml file using the `ilib-loctool-yaml` plugin.
+
+Any fields not listed in the frontmatter list will be preserved but not be localized.
+If frontmatter is set to "true" instead of an array,
+all fields will be localized. If frontmatter is set to "false", or if it is not
+given, then no fields will be localized.
 
 ## License
 
@@ -38,6 +49,7 @@ file for more details.
 ### v1.8.0
 
 - added support for settings mappings
+- added support for parsing and localizing frontmatter fields
 
 ### v1.7.2
 

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "dependencies": {
         "he": "^1.2.0",
         "ilib": "^14.9.0",
+        "ilib-loctool-yaml": "^1.1.1",
         "log4js": "^5.3.0",
         "message-accumulator": "^2.2.1",
         "rehype-raw": "^4.0.2",
@@ -69,7 +70,7 @@
         "unist-util-filter": "^1.0.2"
     },
     "devDependencies": {
-        "loctool": "^2.9.0",
+        "loctool": "^2.13.1",
         "nodeunit": "^0.11.3"
     }
 }

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3468,7 +3468,7 @@ module.exports.markdown = {
             datatype: "x-yaml"
         }));
 
-        // should ignore the front matter and leave it unlocalized
+        // should localize the front matter because the mapping includes Title and Description
         var expected =
             '---\n' +
             'Description: |\n' +
@@ -3544,7 +3544,7 @@ module.exports.markdown = {
             datatype: "x-yaml"
         }));
 
-        // should ignore the front matter and leave it unlocalized
+        // should ignore the front matter it doesn't recognize and leave it unlocalized
         var expected =
             '---\n' +
             'Description: |\n' +
@@ -3630,7 +3630,7 @@ module.exports.markdown = {
             datatype: "x-yaml"
         }));
 
-        // should ignore the front matter and leave it unlocalized
+        // should localize all the front matter
         var expected =
             '---\n' +
             'Description: |\n' +

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -93,10 +93,12 @@ var p3 = new CustomProject({
                 template: "[locale]/bar/[filename]"
             },
             "**/asdf.md": {
-                template: "[dir]/[locale]/bar/[filename]"
+                template: "[dir]/[locale]/bar/[filename]",
+                frontmatter: ["test"]
             },
             "**/x/*.md": {
-                template: "[dir]/[base]_[locale].md"
+                template: "[dir]/[base]_[locale].md",
+                frontmatter: ["Title", "Description"]
             },
             "**/y/*.md": {
                 template: "[dir]/[locale]/[base].md"
@@ -1807,8 +1809,9 @@ module.exports.markdown = {
         test.expect(10);
 
         var mf = new MarkdownFile({
-            project: p,
-            type: mdft
+            project: p3,
+            type: mdft3,
+            pathName: "foo/bar.md"  // no frontmatter config
         });
         test.ok(mf);
 
@@ -1842,11 +1845,13 @@ module.exports.markdown = {
         test.done();
     },
 
-    testMarkdownFileParseWithFrontMatter: function(test) {
+    testMarkdownFileParseWithFrontMatterExtract: function(test) {
         test.expect(11);
 
         var mf = new MarkdownFile({
-            project: p2
+            project: p3,
+            type: mdft3,
+            pathName: "foo/bar/asdf.md"
         });
         test.ok(mf);
 

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -1842,6 +1842,43 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileParseWithFrontMatter: function(test) {
+        test.expect(11);
+
+        var mf = new MarkdownFile({
+            project: p2
+        });
+        test.ok(mf);
+
+        mf.parse(
+            '---\n' +
+            'test: This is a test of the front matter\n' +
+            '---\n\n' +
+            'This is a test\n\n' +
+            'This is also a test\n');
+
+        var set = mf.getTranslationSet();
+        test.ok(set);
+
+        var r = set.getBySource("This is a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test");
+        test.equal(r.getKey(), "r654479252");
+
+        r = set.getBySource("This is also a test");
+        test.ok(r);
+        test.equal(r.getSource(), "This is also a test");
+        test.equal(r.getKey(), "r999080996");
+
+        // the front matter should be extracted because p2 has fm settings
+        r = set.getBySource("This is a test of the front matter");
+        test.ok(r);
+        test.equal(r.getSource(), "This is a test of the front matter");
+        test.equal(r.getKey(), "fm:test");
+
+        test.done();
+    },
+
     testMarkdownFileParseTable: function(test) {
         test.expect(21);
 


### PR DESCRIPTION
- frontmatter is parsed as a yaml file using the ilib-loctool-yaml plugin
- the settings mapping can contain a frontmatter array that specifies which fields to localize, or a boolean that tells it to localize all fields or no fields. When not specified, no fields are localized.
