### PR TITLE
Mark a file as not fully translated if there is pseudo translation

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -773,7 +773,6 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
                 datatype: "markdown",
                 index: this.resourceIndex++
             }));
-            this.translationStatus[locale] = false; // mark this file as not fully translated in this locale
 
             translation = source;
 
@@ -781,6 +780,7 @@ MarkdownFile.prototype._localizeString = function(source, locale, translations) 
                 translation = this.type.missingPseudo.getString(source);
             }
         }
+        this.translationStatus[locale] = false; // mark this file as not fully translated in this locale
     } else {
         translation = source;
         this.translationStatus[locale] = false; // mark this file as not fully translated in this locale


### PR DESCRIPTION
Previously, it only marked the file as not fully translated if there
were any new strings but not if there were pseudo translated strings.