### PR TITLE
Fixed a bug with new strings for frontmatter

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -36,7 +36,6 @@ var footnotes = require('remark-footnotes');
 var he = require("he");
 var unistFilter = require('unist-util-filter');
 var u = require('unist-builder');
-var YamlFileType = require('ilib-loctool-yaml');
 
 var logger = log4js.getLogger("loctool.lib.MarkdownFile");
 
@@ -144,9 +143,9 @@ var MarkdownFile = function(options) {
 
     if (this.mapping && this.mapping.frontmatter) {
         // needed to parse the front matter, which is in yaml format
-        var type = new YamlFileType(this.project);
-        this.yamlfile = type.newFile({
-            pathName: this.pathName
+        var type = this.type.getYamlFileType();
+        this.yamlfile = type.newFile(this.pathName, {
+            sourceLocale: this.project.getSourceLocale()
         });
     }
 };

--- a/MarkdownFileType.js
+++ b/MarkdownFileType.js
@@ -22,6 +22,7 @@ var path = require("path");
 var log4js = require("log4js");
 var mm = require("micromatch");
 var MarkdownFile = require("./MarkdownFile.js");
+var YamlFileType = require('ilib-loctool-yaml');
 
 var logger = log4js.getLogger("loctool.lib.MarkdownFileType");
 
@@ -56,6 +57,8 @@ var MarkdownFileType = function(project) {
         translated: [],
         untranslated: []
     }
+
+    this.yamlFileType = new YamlFileType(this.project);
 };
 
 var defaultMappings = {
@@ -229,7 +232,12 @@ MarkdownFileType.prototype.addSet = function(set) {
  * new resources
  */
 MarkdownFileType.prototype.getNew = function() {
-    return this.newres;
+    // get the new strings from the front matter and the file itself and
+    // put them together
+    var set = this.API.newTranslationSet(this.project.getSourceLocale());
+    set.addSet(this.yamlFileType.getNew());
+    set.addSet(this.newres);
+    return set;
 };
 
 /**
@@ -240,7 +248,12 @@ MarkdownFileType.prototype.getNew = function() {
  * pseudo localized resources
  */
 MarkdownFileType.prototype.getPseudo = function() {
-    return this.pseudo;
+    // get the pseudo strings from the front matter and the file itself and
+    // put them together
+    var set = this.API.newTranslationSet(this.project.getSourceLocale());
+    set.addSet(this.yamlFileType.getPseudo());
+    set.addSet(this.pseudo);
+    return set;
 };
 
 MarkdownFileType.prototype.addTranslationStatus = function(fileInfo) {
@@ -256,6 +269,13 @@ MarkdownFileType.prototype.projectClose = function() {
         var fileName = path.join(this.project.root, "translation-status.json");
         fs.writeFileSync(fileName, JSON.stringify(this.fileInfo, undefined, 4), "utf-8");
     }
+};
+
+/**
+ * @private
+ */
+MarkdownFileType.prototype.getYamlFileType = function() {
+    return this.yamlFileType;
 };
 
 module.exports = MarkdownFileType;

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ file for more details.
 
 ## Release Notes
 
+### v1.8.2
+
+- fixed a bug where the new and pseudo strings for the front matter were not
+  being generated properly
+
 ### v1.8.1
 
 - fixed incorrect documentation (ie. the above text!)

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "unist-util-filter": "^1.0.2"
     },
     "devDependencies": {
-        "loctool": "^2.13.1",
+        "loctool": "^2.14.1",
         "nodeunit": "^0.11.3"
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.8.1",
+    "version": "1.8.2",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",

--- a/test/testMarkdownFile.js
+++ b/test/testMarkdownFile.js
@@ -3485,6 +3485,81 @@ module.exports.markdown = {
         test.done();
     },
 
+    testMarkdownFileLocalizeTextProcessFrontMatterProcessNewStrings: function(test) {
+        test.expect(12);
+
+        var mf = new MarkdownFile({
+            project: p3,
+            type: mdft3,
+            pathName: "a/b/x/foo.md"
+        });
+        test.ok(mf);
+
+        mdft3.newres.clear();
+
+        mf.parse(
+            '---\n' +
+            'Title: This is a test of the front matter\n' +
+            'Description: |\n' +
+            '  another front matter description\n' +
+            '  with extended text\n' +
+            '---\n\n' +
+            'This is a test\n\n' +
+            'This is also a test\n');
+
+        var translations = new TranslationSet();
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "r654479252",
+            source: "This is a test",
+            sourceLocale: "en-US",
+            target: "Ceci est un essai",
+            targetLocale: "fr-FR",
+            datatype: "markdown"
+        }));
+        translations.add(new ResourceString({
+            project: "foo",
+            key: "Title",
+            source: "This is a test of the front matter",
+            sourceLocale: "en-US",
+            target: "Ceci est aussi un essai de la question en face",
+            targetLocale: "fr-FR",
+            datatype: "x-yaml"
+        }));
+
+        // should localize the front matter because the mapping includes Title and Description
+        var expected =
+            '---\n' +
+            'Description: |\n' +
+            '  another front matter description\n' +
+            '  with extended text\n' +
+            'Title: Ceci est aussi un essai de la question en face\n' +
+            '---\n' +
+            'Ceci est un essai\n\n' +
+            'This is also a test\n';
+        var actual = mf.localizeText(translations, "fr-FR");
+
+        diff(actual, expected);
+        test.equal(actual, expected);
+
+        var newset = mdft3.getNew();
+        test.ok(newset);
+        var resources = newset.getAll();
+        test.equal(resources.length, 2);
+
+        test.equal(resources[0].getKey(), "Description");
+        test.equal(resources[0].getSource(), "another front matter description\nwith extended text\n");
+        test.equal(resources[0].getSourceLocale(), "en-US");
+        test.equal(resources[0].getPath(), "a/b/x/foo.md");
+
+        test.equal(resources[1].getKey(), "r999080996");
+        test.equal(resources[1].getSource(), "This is also a test");
+        test.equal(resources[1].getSourceLocale(), "en-US");
+        test.equal(resources[1].getPath(), "a/b/x/foo.md");
+
+        test.done();
+    },
+
     testMarkdownFileLocalizeTextProcessFrontMatterSkipUnknownFields: function(test) {
         test.expect(2);
 


### PR DESCRIPTION
Fixed a bug where the new strings generated by the yaml file instance
used to parse the frontmatter was not being added to the new
strings for the markdown file itself. Same things with the pseudo
strings.