### PR TITLE
Fix incorrectly localized url resources

### DIFF
--- a/MarkdownFile.js
+++ b/MarkdownFile.js
@@ -598,7 +598,7 @@ MarkdownFile.prototype._walk = function(node) {
                 // or if this text contains anything that is not whitespace
                 if (parts.text) {
                     this._addTransUnit(node.url);
-                    node.localizable = true;
+                    node.localizedLink = true;
                 }
             }
             if (node.children && node.children.length) {
@@ -1006,7 +1006,7 @@ MarkdownFile.prototype._localizeNode = function(node, message, locale, translati
             if (node.title) {
                node.title = this._localizeString(node.title, locale, translations);
             }
-            if (node.url && node.localizable) {
+            if (node.url && node.localizedLink) {
                 // don't pseudo-localize URLs
                 node.url = this._localizeString(node.url, locale, translations, true);
             }

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ file for more details.
 
 ## Release Notes
 
+### v1.9.1
+
+- fixed a bug where URLs in direct links were added to the new strings set
+  even when the localize-links directive was turned off. If the "fully
+  translated" flag was also turned on, then the plugin would think a file was
+  not fully translated because these links appear in the new strings set
+  and so it would not produce the localized version of the file.
+
 ### v1.9.0
 
 - added the ability to localize URLs in direct links when the localize-links

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-loctool-ghfm",
-    "version": "1.9.0",
+    "version": "1.9.1",
     "main": "./MarkdownFileType.js",
     "description": "A loctool plugin that knows how to process github-flavored markdown files",
     "license": "Apache-2.0",


### PR DESCRIPTION
Fixed a bug where URLs in direct links were added to the new strings set even when the localize-links directive was turned off. If the "fully translated" flag was also turned on, then the plugin would think a file was not fully translated because these links appear in the new strings set and so it would not produce the localized version of the file.